### PR TITLE
refactor(operations): toolbar consistency for Pending Tasks & Employees

### DIFF
--- a/gatic/resources/views/livewire/employees/employees-index.blade.php
+++ b/gatic/resources/views/livewire/employees/employees-index.blade.php
@@ -1,145 +1,236 @@
-<div class="container position-relative">
-    <x-ui.long-request target="save,delete" />
+<div class="container position-relative operations-page operations-employees-page">
+    <x-ui.long-request target="save,delete,edit,cancelEdit" />
+
+    @php
+        $hasSearch = trim($this->search) !== '';
+        $resultsCount = $employees->total();
+        $isEditingThisPage = (bool) $isEditing;
+    @endphp
 
     <div class="row justify-content-center">
-        <div class="col-12 col-lg-10">
-            <div class="card">
-                <div class="card-header d-flex justify-content-between align-items-center">
-                    <div class="d-flex flex-column">
-                        <x-ui.breadcrumbs :items="[
-                            ['label' => 'Inicio', 'url' => route('dashboard')],
-                            ['label' => 'Empleados', 'url' => null],
-                        ]" />
-                        <span class="fw-medium">Empleados</span>
-                    </div>
+        <div class="col-12 col-xxl-11">
+            <x-ui.toolbar
+                title="Empleados"
+                subtitle="Gestiona empleados para asignaciones, préstamos y trazabilidad."
+                filterId="employees-filters"
+                :filtersCollapsible="false"
+            >
+                <x-slot:breadcrumbs>
+                    <x-ui.breadcrumbs :items="[
+                        ['label' => 'Inicio', 'url' => route('dashboard')],
+                        ['label' => 'Operaciones', 'url' => route('employees.index')],
+                        ['label' => 'Empleados', 'url' => null],
+                    ]" />
+                </x-slot:breadcrumbs>
+
+                <x-slot:actions>
+                    <x-ui.badge tone="neutral" variant="compact" :with-rail="false">
+                        Total <strong>{{ number_format($resultsCount) }}</strong>
+                    </x-ui.badge>
+                    @if ($hasSearch)
+                        <x-ui.badge tone="neutral" variant="compact" :with-rail="false">
+                            Resultados <strong>{{ number_format($resultsCount) }}</strong>
+                        </x-ui.badge>
+                    @endif
+                    @if ($isEditingThisPage)
+                        <x-ui.badge tone="warning" variant="compact" :with-rail="false" icon="bi-pencil-square">Editando</x-ui.badge>
+                    @endif
+
                     <x-ui.column-manager table="employees" />
-                </div>
+                </x-slot:actions>
 
-                <div class="card-body">
-                    <div class="row g-3 mb-3">
-                        <div class="col-12 col-md-6">
-                            <label for="employees-search" class="form-label">Buscar</label>
-                            <input
-                                id="employees-search"
-                                type="text"
-                                class="form-control"
-                                placeholder="Buscar por RPE o nombre."
-                                wire:model.live.debounce.300ms="search"
-                            />
-                        </div>
+                <x-slot:search>
+                    <label for="employees-search" class="form-label">Buscar</label>
+                    <div class="input-group">
+                        <span class="input-group-text bg-body">
+                            <i class="bi bi-search" aria-hidden="true"></i>
+                        </span>
+                        <input
+                            id="employees-search"
+                            type="search"
+                            class="form-control"
+                            placeholder="Buscar por RPE o nombre…"
+                            wire:model.live.debounce.300ms="search"
+                            aria-label="Buscar empleado por RPE o nombre"
+                            autocomplete="off"
+                        />
                     </div>
+                </x-slot:search>
 
-                    <div class="card bg-body-tertiary mb-3">
-                        <div class="card-body">
-                            <h6 class="card-title">{{ $isEditing ? 'Editar empleado' : 'Nuevo empleado' }}</h6>
+                <x-slot:filters>
+                    <div class="col-12 col-md-9">
+                        <div class="card bg-body-tertiary">
+                            <div class="card-body">
+                                <div class="d-flex align-items-start justify-content-between gap-3">
+                                    <div class="min-w-0">
+                                        <div class="fw-semibold">
+                                            <i class="bi bi-person-badge me-1" aria-hidden="true"></i>
+                                            {{ $isEditingThisPage ? 'Editar empleado' : 'Nuevo empleado' }}
+                                        </div>
+                                        <div class="small text-body-secondary">
+                                            @if ($isEditingThisPage)
+                                                Actualiza la información del empleado seleccionado.
+                                            @else
+                                                Agrega empleados para usarlos en asignaciones y préstamos.
+                                            @endif
+                                        </div>
+                                    </div>
 
-                            <div class="row g-3">
-                                <div class="col-12 col-md-3">
-                                    <label for="employee-rpe" class="form-label">RPE</label>
-                                    <input
-                                        id="employee-rpe"
-                                        type="text"
-                                        class="form-control @error('rpe') is-invalid @enderror"
-                                        placeholder="RPE"
-                                        wire:model="rpe"
-                                    />
-                                    @error('rpe')
-                                        <div class="invalid-feedback">{{ $message }}</div>
-                                    @enderror
+                                    @if ($isEditingThisPage)
+                                        <span class="small text-body-secondary">ID {{ $this->employeeId }}</span>
+                                    @endif
                                 </div>
 
-                                <div class="col-12 col-md-3">
-                                    <label for="employee-name" class="form-label">Nombre</label>
-                                    <input
-                                        id="employee-name"
-                                        type="text"
-                                        class="form-control @error('name') is-invalid @enderror"
-                                        placeholder="Nombre completo"
-                                        wire:model="name"
-                                    />
-                                    @error('name')
-                                        <div class="invalid-feedback">{{ $message }}</div>
-                                    @enderror
+                                <div class="row g-3 mt-1">
+                                    <div class="col-12 col-md-3">
+                                        <label for="employee-rpe" class="form-label">RPE</label>
+                                        <input
+                                            id="employee-rpe"
+                                            type="text"
+                                            class="form-control @error('rpe') is-invalid @enderror"
+                                            placeholder="RPE"
+                                            wire:model="rpe"
+                                            autocomplete="off"
+                                        />
+                                        @error('rpe')
+                                            <div class="invalid-feedback">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-12 col-md-3">
+                                        <label for="employee-name" class="form-label">Nombre</label>
+                                        <input
+                                            id="employee-name"
+                                            type="text"
+                                            class="form-control @error('name') is-invalid @enderror"
+                                            placeholder="Nombre completo"
+                                            wire:model="name"
+                                            autocomplete="off"
+                                        />
+                                        @error('name')
+                                            <div class="invalid-feedback">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-12 col-md-3">
+                                        <label for="employee-department" class="form-label">Departamento</label>
+                                        <input
+                                            id="employee-department"
+                                            type="text"
+                                            class="form-control @error('department') is-invalid @enderror"
+                                            placeholder="Departamento (opcional)"
+                                            wire:model="department"
+                                            autocomplete="off"
+                                        />
+                                        @error('department')
+                                            <div class="invalid-feedback">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-12 col-md-3">
+                                        <label for="employee-job-title" class="form-label">Puesto</label>
+                                        <input
+                                            id="employee-job-title"
+                                            type="text"
+                                            class="form-control @error('jobTitle') is-invalid @enderror"
+                                            placeholder="Puesto (opcional)"
+                                            wire:model="jobTitle"
+                                            autocomplete="off"
+                                        />
+                                        @error('jobTitle')
+                                            <div class="invalid-feedback">{{ $message }}</div>
+                                        @enderror
+                                    </div>
                                 </div>
 
-                                <div class="col-12 col-md-3">
-                                    <label for="employee-department" class="form-label">Departamento</label>
-                                    <input
-                                        id="employee-department"
-                                        type="text"
-                                        class="form-control @error('department') is-invalid @enderror"
-                                        placeholder="Departamento (opcional)"
-                                        wire:model="department"
-                                    />
-                                    @error('department')
-                                        <div class="invalid-feedback">{{ $message }}</div>
-                                    @enderror
-                                </div>
-
-                                <div class="col-12 col-md-3">
-                                    <label for="employee-job-title" class="form-label">Puesto</label>
-                                    <input
-                                        id="employee-job-title"
-                                        type="text"
-                                        class="form-control @error('jobTitle') is-invalid @enderror"
-                                        placeholder="Puesto (opcional)"
-                                        wire:model="jobTitle"
-                                    />
-                                    @error('jobTitle')
-                                        <div class="invalid-feedback">{{ $message }}</div>
-                                    @enderror
-                                </div>
-                            </div>
-
-                            <div class="mt-3">
-                                <button
-                                    type="button"
-                                    class="btn btn-primary"
-                                    wire:click="save"
-                                    wire:loading.attr="disabled"
-                                    wire:target="save"
-                                >
-                                    Guardar
-                                </button>
-
-                                @if ($isEditing)
+                                <div class="mt-3 d-flex flex-wrap gap-2">
                                     <button
                                         type="button"
-                                        class="btn btn-outline-secondary"
-                                        wire:click="cancelEdit"
+                                        class="btn btn-primary"
+                                        wire:click="save"
                                         wire:loading.attr="disabled"
-                                        wire:target="cancelEdit"
+                                        wire:target="save"
+                                        aria-label="{{ $isEditingThisPage ? 'Guardar cambios de empleado' : 'Guardar nuevo empleado' }}"
                                     >
-                                        Cancelar
+                                        <span wire:loading.remove wire:target="save">
+                                            <i class="bi bi-check2-circle me-1" aria-hidden="true"></i>
+                                            {{ $isEditingThisPage ? 'Guardar cambios' : 'Guardar' }}
+                                        </span>
+                                        <span wire:loading.inline wire:target="save">
+                                            <span class="d-inline-flex align-items-center gap-2">
+                                                <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+                                                Guardando…
+                                            </span>
+                                        </span>
                                     </button>
-                                @endif
+
+                                    @if ($isEditingThisPage)
+                                        <button
+                                            type="button"
+                                            class="btn btn-outline-secondary"
+                                            wire:click="cancelEdit"
+                                            wire:loading.attr="disabled"
+                                            wire:target="cancelEdit"
+                                        >
+                                            <i class="bi bi-x-lg me-1" aria-hidden="true"></i>
+                                            Cancelar
+                                        </button>
+                                    @endif
+                                </div>
                             </div>
                         </div>
                     </div>
+                </x-slot:filters>
 
-                    <div class="table-responsive-xl">
-                        <table class="table table-sm table-striped align-middle mb-0" data-column-table="employees">
-                            <thead>
-                                <tr>
-                                    <th data-column-key="rpe" data-column-required="true">RPE</th>
-                                    <th data-column-key="name">Nombre</th>
-                                    <th data-column-key="department">Departamento</th>
-                                    <th data-column-key="job_title">Puesto</th>
-                                    <th data-column-key="actions" data-column-required="true" class="text-end">Acciones</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @forelse ($employees as $employee)
-                                    <tr>
-                                        <td>{{ $employee->rpe }}</td>
-                                        <td>{{ $employee->name }}</td>
-                                        <td>{{ $employee->department ?? '—' }}</td>
-                                        <td>{{ $employee->job_title ?? '—' }}</td>
-                                        <td class="text-end">
+                <x-slot:clearFilters>
+                    @if ($hasSearch)
+                        <button
+                            type="button"
+                            class="btn btn-outline-secondary w-100"
+                            wire:click="$set('search', '')"
+                            aria-label="Limpiar búsqueda"
+                        >
+                            <i class="bi bi-x-lg me-1" aria-hidden="true"></i>
+                            Limpiar
+                        </button>
+                    @endif
+                </x-slot:clearFilters>
+
+                <div class="small text-body-secondary mb-2">
+                    Mostrando {{ number_format($resultsCount) }} resultado{{ $resultsCount === 1 ? '' : 's' }}.
+                </div>
+
+                <div class="table-responsive-xl border rounded-3">
+                    <table class="table table-sm table-striped align-middle mb-0 table-gatic-head" data-column-table="employees">
+                        <thead>
+                            <tr>
+                                <th data-column-key="rpe" data-column-required="true">RPE</th>
+                                <th data-column-key="name">Nombre</th>
+                                <th data-column-key="department">Departamento</th>
+                                <th data-column-key="job_title">Puesto</th>
+                                <th data-column-key="actions" data-column-required="true" class="text-end">Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($employees as $employee)
+                                <tr wire:key="employee-row-{{ $employee->id }}">
+                                    <td class="fw-semibold">{{ $employee->rpe }}</td>
+                                    <td class="min-w-0">
+                                        <div class="min-w-0">
+                                            <div class="fw-semibold text-truncate">{{ $employee->name }}</div>
+                                            <div class="small text-body-secondary">ID {{ $employee->id }}</div>
+                                        </div>
+                                    </td>
+                                    <td>{{ $employee->department ?? '—' }}</td>
+                                    <td>{{ $employee->job_title ?? '—' }}</td>
+                                    <td class="text-end">
+                                        <div class="d-inline-flex flex-wrap justify-content-end gap-2">
                                             <a
                                                 href="{{ route('employees.show', $employee->id) }}"
                                                 class="btn btn-sm btn-outline-secondary"
+                                                aria-label="Ver ficha de {{ $employee->rpe }}"
                                             >
+                                                <i class="bi bi-eye me-1" aria-hidden="true"></i>
                                                 Ver ficha
                                             </a>
                                             <button
@@ -148,7 +239,9 @@
                                                 wire:click="edit({{ $employee->id }})"
                                                 wire:loading.attr="disabled"
                                                 wire:target="edit"
+                                                aria-label="Editar empleado {{ $employee->rpe }}"
                                             >
+                                                <i class="bi bi-pencil-square me-1" aria-hidden="true"></i>
                                                 Editar
                                             </button>
                                             <button
@@ -158,25 +251,38 @@
                                                 wire:confirm="¿Confirmas que deseas eliminar este empleado?"
                                                 wire:loading.attr="disabled"
                                                 wire:target="delete"
+                                                aria-label="Eliminar empleado {{ $employee->rpe }}"
                                             >
+                                                <i class="bi bi-trash me-1" aria-hidden="true"></i>
                                                 Eliminar
                                             </button>
-                                        </td>
-                                    </tr>
-                                @empty
-                                    <tr>
-                                        <td colspan="5" class="text-muted">No hay empleados.</td>
-                                    </tr>
-                                @endforelse
-                            </tbody>
-                        </table>
-                    </div>
-
-                    <div class="mt-3">
-                        {{ $employees->links() }}
-                    </div>
+                                        </div>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="5">
+                                        @if ($hasSearch)
+                                            <x-ui.empty-state variant="filter" compact />
+                                        @else
+                                            <x-ui.empty-state
+                                                icon="bi-person-badge"
+                                                title="No hay empleados"
+                                                description="Crea tu primer empleado para comenzar a registrar asignaciones y préstamos."
+                                                compact
+                                            />
+                                        @endif
+                                    </td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
                 </div>
-            </div>
+
+                <div class="mt-3">
+                    {{ $employees->links() }}
+                </div>
+            </x-ui.toolbar>
         </div>
     </div>
 </div>

--- a/gatic/resources/views/livewire/pending-tasks/pending-tasks-index.blade.php
+++ b/gatic/resources/views/livewire/pending-tasks/pending-tasks-index.blade.php
@@ -1,132 +1,175 @@
-<div class="container position-relative">
+<div class="container position-relative operations-page operations-pending-tasks-page">
     <x-ui.long-request />
+
+    @php
+        $resultsCount = $tasks->total();
+        $hasFilters = $this->hasActiveFilters();
+    @endphp
+
     <div class="row justify-content-center">
-        <div class="col-12 col-lg-10">
-            <div class="card">
-                <div class="card-header d-flex justify-content-between align-items-center">
-                    <div class="d-flex flex-column">
-                        <x-ui.breadcrumbs :items="[
-                            ['label' => 'Inicio', 'url' => route('dashboard')],
-                            ['label' => 'Tareas pendientes', 'url' => null],
-                        ]" />
-                        <span class="fw-medium">Tareas pendientes</span>
+        <div class="col-12 col-xxl-11">
+            <x-ui.toolbar
+                title="Tareas pendientes"
+                subtitle="Procesa movimientos en lote con locks para evitar duplicados."
+                filterId="pending-tasks-filters"
+                :filtersCollapsible="false"
+            >
+                <x-slot:breadcrumbs>
+                    <x-ui.breadcrumbs :items="[
+                        ['label' => 'Inicio', 'url' => route('dashboard')],
+                        ['label' => 'Operaciones', 'url' => route('pending-tasks.index')],
+                        ['label' => 'Tareas pendientes', 'url' => null],
+                    ]" />
+                </x-slot:breadcrumbs>
+
+                <x-slot:actions>
+                    <x-ui.badge tone="neutral" variant="compact" :with-rail="false">
+                        Resultados <strong>{{ number_format($resultsCount) }}</strong>
+                    </x-ui.badge>
+
+                    <x-ui.column-manager table="pending-tasks" />
+                    <livewire:pending-tasks.quick-stock-in :key="'quick-stock-in-index'" />
+                    <livewire:pending-tasks.quick-retirement :key="'quick-retirement-index'" />
+                    <livewire:pending-tasks.pending-task-opener :key="'pending-task-opener-index'" />
+
+                    <a class="btn btn-sm btn-primary" href="{{ route('pending-tasks.create') }}">
+                        <i class="bi bi-plus-lg me-1" aria-hidden="true"></i>
+                        Nueva tarea
+                    </a>
+                </x-slot:actions>
+
+                <x-slot:filters>
+                    <div class="col-12 col-md-3">
+                        <label for="filter-status" class="form-label">Estado</label>
+                        <select
+                            id="filter-status"
+                            class="form-select"
+                            wire:model.live="statusFilter"
+                            aria-label="Filtrar por estado"
+                        >
+                            <option value="">Todos</option>
+                            @foreach ($statuses as $status)
+                                <option value="{{ $status->value }}">{{ $status->label() }}</option>
+                            @endforeach
+                        </select>
                     </div>
-                    <div class="d-flex gap-2 align-items-center">
-                        <x-ui.column-manager table="pending-tasks" />
-                        <livewire:pending-tasks.quick-stock-in :key="'quick-stock-in-index'" />
-                        <livewire:pending-tasks.quick-retirement :key="'quick-retirement-index'" />
-                        <livewire:pending-tasks.pending-task-opener :key="'pending-task-opener-index'" />
-                        <a class="btn btn-sm btn-primary" href="{{ route('pending-tasks.create') }}">Nueva tarea</a>
+
+                    <div class="col-12 col-md-3">
+                        <label for="filter-type" class="form-label">Tipo de operación</label>
+                        <select
+                            id="filter-type"
+                            class="form-select"
+                            wire:model.live="typeFilter"
+                            aria-label="Filtrar por tipo"
+                        >
+                            <option value="">Todos</option>
+                            @foreach ($types as $type)
+                                <option value="{{ $type->value }}">{{ $type->label() }}</option>
+                            @endforeach
+                        </select>
                     </div>
+                </x-slot:filters>
+
+                <x-slot:clearFilters>
+                    @if ($hasFilters)
+                        <button
+                            type="button"
+                            class="btn btn-outline-secondary w-100"
+                            wire:click="clearFilters"
+                            aria-label="Limpiar filtros"
+                        >
+                            <i class="bi bi-x-lg me-1" aria-hidden="true"></i>
+                            Limpiar
+                        </button>
+                    @endif
+                </x-slot:clearFilters>
+
+                <div class="small text-body-secondary mb-2">
+                    Mostrando {{ number_format($resultsCount) }} resultado{{ $resultsCount === 1 ? '' : 's' }}.
                 </div>
 
-                <div class="card-body">
-                    <div class="row g-3 align-items-end mb-3">
-                        <div class="col-12 col-md-3">
-                            <label for="filter-status" class="form-label">Estado</label>
-                            <select
-                                id="filter-status"
-                                class="form-select"
-                                wire:model.live="statusFilter"
-                                aria-label="Filtrar por estado"
-                            >
-                                <option value="">Todos</option>
-                                @foreach ($statuses as $status)
-                                    <option value="{{ $status->value }}">{{ $status->label() }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div class="col-12 col-md-3">
-                            <label for="filter-type" class="form-label">Tipo de operación</label>
-                            <select
-                                id="filter-type"
-                                class="form-select"
-                                wire:model.live="typeFilter"
-                                aria-label="Filtrar por tipo"
-                            >
-                                <option value="">Todos</option>
-                                @foreach ($types as $type)
-                                    <option value="{{ $type->value }}">{{ $type->label() }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div class="col-12 col-md-2">
-                            @if ($this->hasActiveFilters())
-                                <button
-                                    type="button"
-                                    class="btn btn-outline-secondary w-100"
-                                    wire:click="clearFilters"
-                                    aria-label="Limpiar todos los filtros"
-                                >
-                                    Limpiar
-                                </button>
-                            @endif
-                        </div>
-                    </div>
-
-                    <div class="table-responsive-xl">
-                        <table class="table table-sm table-striped align-middle mb-0" data-column-table="pending-tasks">
-                            <thead>
-                                <tr>
-                                    <th data-column-key="id" data-column-required="true">ID</th>
-                                    <th data-column-key="type">Tipo</th>
-                                    <th data-column-key="status">Estado</th>
-                                    <th data-column-key="lines">Renglones</th>
-                                    <th data-column-key="creator">Creador</th>
-                                    <th data-column-key="created_at">Fecha</th>
-                                    <th data-column-key="actions" data-column-required="true" class="text-end">Acciones</th>
+                <div class="table-responsive-xl border rounded-3">
+                    <table
+                        class="table table-sm table-striped align-middle mb-0 table-gatic-head"
+                        data-column-table="pending-tasks"
+                    >
+                        <thead>
+                            <tr>
+                                <th data-column-key="id" data-column-required="true">ID</th>
+                                <th data-column-key="type">Tipo</th>
+                                <th data-column-key="status">Estado</th>
+                                <th data-column-key="lines">Renglones</th>
+                                <th data-column-key="creator">Creador</th>
+                                <th data-column-key="created_at">Fecha</th>
+                                <th data-column-key="actions" data-column-required="true" class="text-end">Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($tasks as $task)
+                                @php
+                                    $isQuickCapture = $task->isQuickCaptureTask();
+                                    $quickKind = is_array($task->payload ?? null) ? ($task->payload['kind'] ?? null) : null;
+                                    $quickLabel = $quickKind === 'quick_stock_in'
+                                        ? 'Carga rápida'
+                                        : ($quickKind === 'quick_retirement' ? 'Retiro rápido' : 'Captura rápida');
+                                @endphp
+                                <tr wire:key="pending-task-row-{{ $task->id }}">
+                                    <td class="fw-semibold">{{ $task->id }}</td>
+                                    <td class="min-w-0">
+                                        <div class="d-flex align-items-center gap-2 flex-wrap min-w-0">
+                                            <span class="text-truncate">{{ $task->type->label() }}</span>
+                                            @if ($isQuickCapture)
+                                                <x-ui.badge tone="info" variant="compact" :with-rail="false">{{ $quickLabel }}</x-ui.badge>
+                                            @endif
+                                        </div>
+                                    </td>
+                                    <td>
+                                        <x-ui.badge :tone="$task->status->badgeTone()" variant="compact">
+                                            {{ $task->status->label() }}
+                                        </x-ui.badge>
+                                    </td>
+                                    <td>{{ $task->lines_count }}</td>
+                                    <td class="min-w-0">
+                                        <span class="text-truncate d-inline-block" style="max-width: 16rem;">
+                                            {{ $task->creator->name ?? '—' }}
+                                        </span>
+                                    </td>
+                                    <td>{{ $task->created_at->format('d/m/Y H:i') }}</td>
+                                    <td class="text-end">
+                                        <a
+                                            class="btn btn-sm btn-outline-secondary"
+                                            href="{{ route('pending-tasks.show', $task->id) }}"
+                                            aria-label="Ver tarea pendiente {{ $task->id }}"
+                                        >
+                                            <i class="bi bi-eye me-1" aria-hidden="true"></i>
+                                            Ver
+                                        </a>
+                                    </td>
                                 </tr>
-                            </thead>
-                            <tbody>
-                                @forelse ($tasks as $task)
-                                    @php
-                                        $isQuickCapture = $task->isQuickCaptureTask();
-                                        $quickKind = is_array($task->payload ?? null) ? ($task->payload['kind'] ?? null) : null;
-                                        $quickLabel = $quickKind === 'quick_stock_in'
-                                            ? 'Carga rapida'
-                                            : ($quickKind === 'quick_retirement' ? 'Retiro rapido' : 'Captura rapida');
-                                    @endphp
-                                    <tr>
-                                        <td>{{ $task->id }}</td>
-                                        <td>
-                                            <div class="d-flex align-items-center gap-2 flex-wrap">
-                                                <span>{{ $task->type->label() }}</span>
-                                                @if ($isQuickCapture)
-                                                    <x-ui.badge tone="info" variant="compact" :with-rail="false">{{ $quickLabel }}</x-ui.badge>
-                                                @endif
-                                            </div>
-                                        </td>
-                                        <td>
-                                            <x-ui.badge :tone="$task->status->badgeTone()" variant="compact">
-                                                {{ $task->status->label() }}
-                                            </x-ui.badge>
-                                        </td>
-                                        <td>{{ $task->lines_count }}</td>
-                                        <td>{{ $task->creator->name ?? '-' }}</td>
-                                        <td>{{ $task->created_at->format('d/m/Y H:i') }}</td>
-                                        <td class="text-end">
-                                            <a
-                                                class="btn btn-sm btn-outline-secondary"
-                                                href="{{ route('pending-tasks.show', $task->id) }}"
-                                            >
-                                                Ver
-                                            </a>
-                                        </td>
-                                    </tr>
-                                @empty
-                                    <tr>
-                                        <td colspan="7" class="text-muted">No hay tareas pendientes.</td>
-                                    </tr>
-                                @endforelse
-                            </tbody>
-                        </table>
-                    </div>
-
-                    <div class="mt-3">
-                        {{ $tasks->links() }}
-                    </div>
+                            @empty
+                                <tr>
+                                    <td colspan="7">
+                                        @if ($hasFilters)
+                                            <x-ui.empty-state variant="filter" compact />
+                                        @else
+                                            <x-ui.empty-state
+                                                icon="bi-list-task"
+                                                title="No hay tareas pendientes"
+                                                description="Cuando generes tareas, aparecerán aquí para su seguimiento y procesamiento."
+                                                compact
+                                            />
+                                        @endif
+                                    </td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
                 </div>
-            </div>
+
+                <div class="mt-3">
+                    {{ $tasks->links() }}
+                </div>
+            </x-ui.toolbar>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Objetivo\n\nAlinear *Operaciones* (Tareas pendientes y Empleados) al patrón visual/UX de Catálogos (toolbar + chips + estados) sin tocar queries/RBAC.\n\n## Cambios\n\n- Pending Tasks index: migrado a <x-ui.toolbar> con breadcrumbs, subtitle, acciones (chips + quick actions + nueva tarea), filtros organizados y empty-state formal.\n- Employees index: migrado a <x-ui.toolbar> con search input-group, chips (total/resultados/editando), editor inline en filters slot, tabla con wrap consistente y empty-state formal.\n- A11y/UX: aria-label en acciones clave, iconos decorativos ria-hidden, microcopy y acentos.\n- Livewire perf: wire:key por fila en ambas tablas (diffs más baratos).\n\n## Archivos\n\n- gatic/resources/views/livewire/pending-tasks/pending-tasks-index.blade.php\n- gatic/resources/views/livewire/employees/employees-index.blade.php\n\n## Validación\n\n- ./vendor/bin/pint --test: PASS\n- phpstan analyse: OK\n- docker compose exec -T laravel.test php artisan test: PASS (885 tests)\n\n## Smoke sugerido\n\n- /pending-tasks (desktop + 768x900)\n- /employees (crear, editar, cancelar, eliminar)\n\n